### PR TITLE
add probem matcher

### DIFF
--- a/.github/matcher/uic_matcher.json
+++ b/.github/matcher/uic_matcher.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "uic-problem-matcher",
+            "pattern": [
+                {
+                    // match things like : generatetargetdlg.ui: Warning: The name 'layoutWidget' (QWidget) is already in use, defaulting to 'layoutWidget1'.
+                    "regexp": "^(.*\\.ui): (Warning):(.*)$",
+                    "file": 1,
+                    "severity": 2,
+                    "message": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -15,5 +15,7 @@ jobs:
       - run: sudo apt install -y apt-utils build-essential wget qt5-qmake qt5-qmake-bin qt5-assistant qtbase5-dev qtmultimedia5-dev libqt5charts5 libqt5charts5-dev libqt5multimedia* libqt5datavisualization5-dev libqt5datavisualization5 libopencv-core-dev libopencv-core4.5d libopencv-dev libqwt-qt5-6 libqwt-qt5-dev libarmadillo-dev libarmadillo10
       - run: qmake
       - uses: ammaraskar/gcc-problem-matcher@master
+      - run: echo "::add-matcher::.github/matcher/uic_matcher.json"
       - run: make -j4
+      - run: echo "::remove-matcher owner=uic-problem-matcher::"
       

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -15,7 +15,7 @@ jobs:
       - run: sudo apt install -y apt-utils build-essential wget qt5-qmake qt5-qmake-bin qt5-assistant qtbase5-dev qtmultimedia5-dev libqt5charts5 libqt5charts5-dev libqt5multimedia* libqt5datavisualization5-dev libqt5datavisualization5 libopencv-core-dev libopencv-core4.5d libopencv-dev libqwt-qt5-6 libqwt-qt5-dev libarmadillo-dev libarmadillo10
       - run: qmake
       - uses: ammaraskar/gcc-problem-matcher@master
-      - run: echo "::add-matcher::.github/matcher/uic_matcher.json"
+      #- run: echo "::add-matcher::.github/matcher/uic_matcher.json" # deactivate uic matcher for now to priorize GCC warnings
       - run: make -j4
-      - run: echo "::remove-matcher owner=uic-problem-matcher::"
+      #- run: echo "::remove-matcher owner=uic-problem-matcher::" # deactivate uic matcher for now to priorize GCC warnings
       

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,4 +14,6 @@ jobs:
       - run: sudo apt update
       - run: sudo apt install -y apt-utils build-essential wget qt5-qmake qt5-qmake-bin qt5-assistant qtbase5-dev qtmultimedia5-dev libqt5charts5 libqt5charts5-dev libqt5multimedia* libqt5datavisualization5-dev libqt5datavisualization5 libopencv-core-dev libopencv-core4.5d libopencv-dev libqwt-qt5-6 libqwt-qt5-dev libarmadillo-dev libarmadillo10
       - run: qmake
+      - uses: ammaraskar/gcc-problem-matcher@master
       - run: make -j4
+      

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -237,6 +237,23 @@ jobs:
     runs-on: windows-latest
     needs: [cache-mingw-from-QT, build-lapack, build-armadillo, build-QWT, build-openCV-with-QT]
     steps:
+
+      # because problem matcher will not work when chechout in a subfolder,
+      # checkout at root and then copy everything in folder.
+      # Match will be done in build folder, and file at root will be used to link the match
+      # Note xheckouting twive is not wokring.
+      # This copy is done before adding any more file into folders
+      - uses: actions/checkout@v3
+      #  with:
+      #    path: 'DFTFringe'
+      
+      # copy all files for problem matcher to work
+      - name: copy files into build folder (problem matcher workaround)
+        run: |
+          mkdir ".\DFTFringe"
+          Copy-Item ".\*" -Destination ".\DFTFringe" -Exclude @("DFTFringe") -Recurse
+
+
       # restore cached minGW
       - uses: actions/cache/restore@v3
         id: cache-minGW
@@ -290,9 +307,8 @@ jobs:
           key: ${{ runner.os }}-openCV-4.6.0-QT-5.15.2
           fail-on-cache-miss: true
 
-      - uses: actions/checkout@v3
-        with:
-          path: 'DFTFringe'
+      # this enables the problem matcher
+      - uses: ammaraskar/gcc-problem-matcher@master
 
       - run: cd DFTFringe ; ..\5.15.2\mingw81_64\bin\qmake.exe
       - run: cd DFTFringe ; mingw32-make -j4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -311,9 +311,9 @@ jobs:
       - uses: ammaraskar/gcc-problem-matcher@master
 
       - run: cd DFTFringe ; ..\5.15.2\mingw81_64\bin\qmake.exe
-      - run: echo "::add-matcher::.github/matcher/uic_matcher.json"
+      #- run: echo "::add-matcher::.github/matcher/uic_matcher.json" # deactivate uic matcher for now to priorize GCC warnings
       - run: cd DFTFringe ; mingw32-make -j4
-      - run: echo "::remove-matcher owner=uic-problem-matcher::"
+      #- run: echo "::remove-matcher owner=uic-problem-matcher::" # deactivate uic matcher for now to priorize GCC warnings
 
       - name: copy needed dlls not found by windeployqt
         run: |

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -311,7 +311,9 @@ jobs:
       - uses: ammaraskar/gcc-problem-matcher@master
 
       - run: cd DFTFringe ; ..\5.15.2\mingw81_64\bin\qmake.exe
+      - run: echo "::add-matcher::.github/matcher/uic_matcher.json"
       - run: cd DFTFringe ; mingw32-make -j4
+      - run: echo "::remove-matcher owner=uic-problem-matcher::"
 
       - name: copy needed dlls not found by windeployqt
         run: |


### PR DESCRIPTION
Hi guys, there is a crazy amount of build warnings. Maybe they are not a big problem but having so much warnings will make new (and potentially problematic) warnings invisible. GitHub has a [feature](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) to show the build warnings in PR. There is a limited number, so I need to fix current warnings so that it becomes really interesting. However this enables the feature.

It will show like 
![image](https://github.com/atsju/DFTFringe/assets/4628382/a82d384a-7b3f-43d8-ba39-6b9be9b6d1d7)


For information: 608 warnings on windows build:
- 12 on ui files
- 52 Wunused-parameter
- 341 Wdeprecated-declarations
- 32 Wunused-local-typedefs
- 9 Wwrite-strings
- 52 Wunused-parameter
- 22 Wsign-compare
- 23 Wunused-but-set-variable
- 48 Wreorder
- 1 Wcatch-value
- 40 Wunused-variable
- 1 Woverflow
- 2 Wmisleading-indentation
- 12 Wmaybe-uninitialized
- 2 Wreturn-type

I might have missed some. And Linux build exhibits some other errors.

Altough `misleading-indentation` is almost pedantic,  `overflow` is just lost in the mass and could have consequences.
